### PR TITLE
chore: move disk encryption from sda2 to sdb

### DIFF
--- a/recipes-core/disk-encryption/disk-encryption.bb
+++ b/recipes-core/disk-encryption/disk-encryption.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "enables persistent disk encryption of /dev/sda2 via tpm2"
 LICENSE = "CLOSED"
-RDEPENDS:${PN} += "cryptsetup tpm2-abrmd tpm2-tss tpm2-tools e2fsprogs-mke2fs parted"
+RDEPENDS:${PN} += "cryptsetup tpm2-abrmd tpm2-tss tpm2-tools e2fsprogs-mke2fs"
 MACHINE_FEATURES += "disk-encryption"
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 SRC_URI += "file://init"

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -18,13 +18,16 @@ LOGFILE=/tmp/disk-encryption.log
 
 start() {
 	echo -n "Starting $DESC: "
-	parted -sf /dev/sda resizepart 2 '100%'
+	if ! [ -f /dev/sdb ] ; then
+		echo "/dev/sdb not found, aborting encrypted disk setup"
+		exit 1
+	fi
 	KEY=''
 	get_key KEY
-	if ! echo -n "$KEY" | cryptsetup luksOpen /dev/sda2 data -; then
+	if ! echo -n "$KEY" | cryptsetup luksOpen /dev/sdb data -; then
 		echo "LUKS volume not opened successfully. Formatting and creating filesystem."
-		echo -n "$KEY" | cryptsetup -q --batch-mode luksFormat /dev/sda2
-		echo -n "$KEY" | cryptsetup luksOpen /dev/sda2 data -
+		echo -n "$KEY" | cryptsetup -q --batch-mode luksFormat /dev/sdb
+		echo -n "$KEY" | cryptsetup luksOpen /dev/sdb data -
 		mkfs.ext4 /dev/mapper/data
 	fi
 	mkdir -p /persistent

--- a/wic/mkefiinitrd.wks
+++ b/wic/mkefiinitrd.wks
@@ -3,6 +3,5 @@
 # can directly dd to boot media.
 
 part /boot --source bootimg-efi --sourceparams="loader=systemd-boot,create-unified-kernel-image=true,initrd=${INITRAMFS_IMAGE}-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label msdos --active --align 1024
-part /data --ondisk sda --label platform --align 1024 --size 128 --use-uuid
 
 bootloader --ptable gpt --timeout=0 --append="console=ttyS0,115200 console=tty0 ramdisk_size=402653184"


### PR DESCRIPTION
moves encrypted disk from sda2 to sdb

this means a disk needs to be attached to the vm that has a second disk sdb attached. this is the case for azure, if you boot it with a 2nd disk attached or with a VM size that provides temporary storage, i.e. the Standard_EC*eds_v5 line.

for local deployment this won't work, we still need to figure out the steps to add a qemu option to add an additional disk.