### PR TITLE
chore: Fix the sdb check

### DIFF
--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -18,7 +18,7 @@ LOGFILE=/tmp/disk-encryption.log
 
 start() {
 	echo -n "Starting $DESC: "
-	if ! [ -f /dev/sdb ] ; then
+	if ! [ -b /dev/sdb ] ; then
 		echo "/dev/sdb not found, aborting encrypted disk setup"
 		exit 1
 	fi


### PR DESCRIPTION
disk and partitions are special block devices and should be checked with "-b" instead of "-f".
The "-f" is usually used for regular files