### PR TITLE
chore: refactor swapfile enabling

### DIFF
--- a/recipes-core/disk-encryption/disk-encryption.bb
+++ b/recipes-core/disk-encryption/disk-encryption.bb
@@ -6,7 +6,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}:"
 SRC_URI += "file://init"
 
 INITSCRIPT_NAME = "disk-encryption"
-INITSCRIPT_PARAMS = "defaults 97"
+INITSCRIPT_PARAMS = "defaults 94"
 
 inherit update-rc.d
 

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -32,39 +32,6 @@ start() {
 	fi
 	mkdir -p /persistent
 	mount /dev/mapper/data /persistent
-	
-	# Create swap file if it doesn't exist
-	if [ ! -f /persistent/swapfile ]; then
-		echo "Creating 512GB swap file..."
-		if ! dd if=/dev/zero of=/persistent/swapfile bs=1G count=512 status=progress; then
-			echo "Error: Failed to create swap file" >&2
-			exit 1
-		fi
-
-		if ! chmod 600 /persistent/swapfile; then
-			echo "Error: Failed to set permissions on swap file" >&2
-			exit 1
-		fi
-
-		if ! mkswap /persistent/swapfile; then
-			echo "Error: Failed to set up swap area" >&2
-			exit 1
-		fi
-	fi
-
-	# Enable swap
-	if ! swapon /persistent/swapfile; then
-		echo "Error: Failed to enable swap" >&2
-		exit 1
-	fi
-
-	# Make swap permanent
-	if ! grep -q "/persistent/swapfile" /etc/fstab; then
-		if ! echo "/persistent/swapfile none swap sw 0 0" >> /etc/fstab; then
-			echo "Error: Failed to add swap entry to /etc/fstab" >&2
-			exit 1
-		fi
-	fi
 	echo "$NAME."
 }
 

--- a/recipes-core/swapfile/init
+++ b/recipes-core/swapfile/init
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides:        swapfile
+# Required-Start:    $remote_fs $syslog $networking
+# Required-Stop:    $remote_fs $syslog
+# Default-Start:    2 3 4 5
+# Default-Stop:        1
+# Short-Description:    Start and stop the swapfile daemon
+### END INIT INFO
+#
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME=swapfile
+DESC="Swapfile"
+LOGFILE=/tmp/swapfile.log
+SWAPFILE_SIZE=512  # This will be replaced by the recipe
+
+start() {
+    echo -n "Starting $DESC: "
+    # Create swap file if it doesn't exist
+    if [ ! -f /persistent/swapfile ]; then
+        echo "Creating ${SWAPFILE_SIZE}GB swap file..."
+        if ! dd if=/dev/zero of=/persistent/swapfile bs=1G count=${SWAPFILE_SIZE} status=progress; then
+            echo "Error: Failed to create swap file" >&2
+            exit 1
+        fi
+        if ! chmod 600 /persistent/swapfile; then
+            echo "Error: Failed to set permissions on swap file" >&2
+            exit 1
+        fi
+        if ! mkswap /persistent/swapfile; then
+            echo "Error: Failed to set up swap area" >&2
+            exit 1
+        fi
+    fi
+    # Enable swap
+    if ! swapon /persistent/swapfile; then
+        echo "Error: Failed to enable swap" >&2
+        exit 1
+    fi
+    # Make swap permanent
+    if ! grep -q "/persistent/swapfile" /etc/fstab; then
+        if ! echo "/persistent/swapfile none swap sw 0 0" >> /etc/fstab; then
+            echo "Error: Failed to add swap entry to /etc/fstab" >&2
+            exit 1
+        fi
+    fi
+    echo "$NAME."
+}
+
+case "$1" in
+  start)
+        start > $LOGFILE 2>&1
+        ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N start" >&2
+    exit 1
+    ;;
+esac
+exit 0

--- a/recipes-core/swapfile/swapfile.bb
+++ b/recipes-core/swapfile/swapfile.bb
@@ -1,0 +1,24 @@
+DESCRIPTION = "enables swapfile on the persistent storage created by disk encryption"
+LICENSE = "CLOSED"
+MACHINE_FEATURES += "swapfile"
+FILESEXTRAPATHS:prepend := "${THISDIR}:"
+SRC_URI += "file://init"
+
+INITSCRIPT_NAME = "swapfile"
+INITSCRIPT_PARAMS = "defaults 95"
+
+inherit update-rc.d
+
+# Default swapfile size (in GB)
+SWAPFILE_SIZE ?= "512"
+
+do_install() {
+    install -d ${D}${sysconfdir}/init.d
+    cp ${WORKDIR}/init ${D}${sysconfdir}/init.d/swapfile
+    chmod 755 ${D}${sysconfdir}/init.d/swapfile
+    
+    # Replace the swapfile size in the init script
+    sed -i 's/SWAPFILE_SIZE=.*/SWAPFILE_SIZE=${SWAPFILE_SIZE}/' ${D}${sysconfdir}/init.d/swapfile
+}
+
+RDEPENDS:${PN} += "disk-encryption"


### PR DESCRIPTION
This PR decouples the swapfile creation and enabling from the disk encryption in its own yocto script.
This would allow more modularity of building the image with or without swapfile.
Also added the ability to set the swapfile size through a config variable (SWAPFILE_SIZE), such that by changing its value in the local.conf, it would also change in the final result