### PR TITLE
chore: fix continuous time sync

### DIFF
--- a/recipes-core/date-sync/date-sync.bb
+++ b/recipes-core/date-sync/date-sync.bb
@@ -1,6 +1,7 @@
-DESCRIPTION = "syncs the date and time of the VM"
+DESCRIPTION = "Syncs the date and time of the VM periodically using BusyBox ntpd"
 LICENSE = "CLOSED"
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
+
 SRC_URI += "file://init"
 
 INITSCRIPT_NAME = "date-sync"
@@ -8,8 +9,28 @@ INITSCRIPT_PARAMS = "defaults 96"
 
 inherit update-rc.d
 
+python () {
+    # Check if TIME_SYNC_INTERVAL is set in the BitBake environment or in local.conf
+    sync_interval = d.getVar('TIME_SYNC_INTERVAL')
+    
+    if sync_interval is None:
+        # If not set in BitBake environment, check the original environment
+        origenv = d.getVar("BB_ORIGENV", False)
+        if origenv:
+            sync_interval = origenv.getVar('TIME_SYNC_INTERVAL')
+    
+    if sync_interval:
+        # If TIME_SYNC_INTERVAL is set (to any non-empty value), keep its value
+        d.setVar('TIME_SYNC_INTERVAL', sync_interval)
+    else:
+        # If TIME_SYNC_INTERVAL is not set, set it to '600' seconds (10 mins) by default
+        d.setVar('TIME_SYNC_INTERVAL', '600')
+
+    bb.note("Time sync interval set to: %s seconds" % d.getVar('TIME_SYNC_INTERVAL'))
+}
+
 do_install() {
-	install -d ${D}${sysconfdir}/init.d
-        cp ${WORKDIR}/init ${D}${sysconfdir}/init.d/date-sync
-        chmod 755 ${D}${sysconfdir}/init.d/date-sync
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/date-sync
+    sed -i 's/SYNC_INTERVAL=60/SYNC_INTERVAL=${TIME_SYNC_INTERVAL}/' ${D}${sysconfdir}/init.d/date-sync
 }

--- a/recipes-core/date-sync/date-sync.bb
+++ b/recipes-core/date-sync/date-sync.bb
@@ -5,7 +5,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}:"
 SRC_URI += "file://init"
 
 INITSCRIPT_NAME = "date-sync"
-INITSCRIPT_PARAMS = "defaults 96"
+INITSCRIPT_PARAMS = "defaults 80"
 
 inherit update-rc.d
 

--- a/recipes-core/date-sync/init
+++ b/recipes-core/date-sync/init
@@ -1,42 +1,76 @@
 #!/bin/sh
-#
 ### BEGIN INIT INFO
-# Provides:		date-sync
-# Required-Start:	$remote_fs $syslog $networking
-# Required-Stop:	$remote_fs $syslog
-# Default-Start:	2 3 4 5
-# Default-Stop:		1
-# Short-Description:	Start and stop the date-sync daemon
+# Provides:             date-sync
+# Required-Start:       $remote_fs $syslog $networking
+# Required-Stop:        $remote_fs $syslog
+# Default-Start:        2 3 4 5
+# Default-Stop:         1
+# Short-Description:    Start and stop the date-sync daemon
 ### END INIT INFO
-#
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME=date-sync
 DESC="Date Sync"
 LOGFILE=/tmp/date-sync.log
+PIDFILE=/var/run/date-sync.pid
 
-start() {
-	echo -n "Starting $DESC: "
+# Configuration
+NTP_SERVER="pool.ntp.org"
+SYNC_INTERVAL=60  # Run every 60 seconds (1 minute)
+MAX_LOG_SIZE=524288  # 512KB (0.5MB) in bytes
 
-	# update time by fetching the latest one from ntp
-	ntpd -q -p pool.ntp.org
-
-	# get current time
-	current_time=$(date)
-
-	echo "Time synchronization completed. New time: $current_time"
-	echo "$NAME."
+log() {
+    echo "$(date +"%Y-%m-%d %H:%M:%S"): $1" >> $LOGFILE
+    if [ -f "$LOGFILE" ] && [ $(stat -c %s "$LOGFILE") -gt $MAX_LOG_SIZE ]; then
+        tail -n 1000 "$LOGFILE" > "${LOGFILE}.tmp" && mv "${LOGFILE}.tmp" "$LOGFILE"
+    fi
 }
 
+sync_time() {
+    log "Synchronizing time with $NTP_SERVER"
+    if ntpd -q -p $NTP_SERVER; then
+        log "Time synchronized successfully"
+    else
+        log "Time synchronization failed"
+    fi
+}
+
+run_daemon() {
+    while true; do
+        sync_time
+        sleep $SYNC_INTERVAL
+    done
+}
+
+start_daemon() {
+    log "Starting $DESC"
+    run_daemon &
+    echo $! > $PIDFILE
+}
+
+stop_daemon() {
+    log "Stopping $DESC"
+    if [ -f $PIDFILE ]; then
+        kill $(cat $PIDFILE)
+        rm $PIDFILE
+    fi
+}
 
 case "$1" in
   start)
-        start > $LOGFILE 2>&1
-        ;;
+	start_daemon
+	;;
+  stop)
+	stop_daemon
+	;;
+  restart)
+	stop_daemon
+	start_daemon
+	;;
   *)
-	N=/etc/init.d/$NAME
-	echo "Usage: $N start" >&2
+	echo "Usage: $0 {start|stop|restart}" >&2
 	exit 1
 	;;
 esac
+
 exit 0

--- a/recipes-core/date-sync/init
+++ b/recipes-core/date-sync/init
@@ -27,11 +27,16 @@ log() {
 }
 
 sync_time() {
-    log "Synchronizing time with $NTP_SERVER"
-    if ntpd -q -p $NTP_SERVER; then
-        log "Time synchronized successfully"
+    ntpd_output=$(ntpd -n -q -d -p $NTP_SERVER 2>&1)
+    if [ $? -eq 0 ]; then
+        offset=$(echo "$ntpd_output" | grep "offset:" | tail -n 1 | sed 's/.*offset:\([^ ]*\).*/\1/')
+        if [ -n "$offset" ]; then
+            log "Time synchronized with $NTP_SERVER successfully. Offset: $offset seconds"
+        else
+            log "Time synchronized with $NTP_SERVER successfully. Offset information not found in output."
+        fi
     else
-        log "Time synchronization failed"
+        log "Time synchronization with $NTP_SERVER failed. Error output: $ntpd_output"
     fi
 }
 


### PR DESCRIPTION
This PR changes the time sync issue from being synced once upon boot to periodically syncing time every one minute.
I've got another approach where we check the current drift from the actual remote ntp server time and based on a specific threshold we either sync or skip while forcing a re-sync upon a different time threshold. However, I think keeping it simple is more beneficial here to reduce resource consumption and execution overhead.
I've added the complex approach as a comment below in case you are interested