### PR TITLE
Change system API revision string format

### DIFF
--- a/recipes-core/system-api/system-api_v0.3.0.bb
+++ b/recipes-core/system-api/system-api_v0.3.0.bb
@@ -9,9 +9,8 @@ INITSCRIPT_NAME = "system-api-init"
 INITSCRIPT_PARAMS = "defaults 81"
 
 GO_IMPORT = "github.com/flashbots/system-api"
-SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main \
+SRC_URI = "git://${GO_IMPORT};protocol=https;nobranch=1;rev=v0.3.0 \
            file://system-api-init"
-SRCREV = "v0.3.0"
 
 GO_INSTALL = "${GO_IMPORT}/cmd/system-api"
 GO_LINKSHARED = ""


### PR DESCRIPTION
I'm getting an error if using the system API's revision string as is:
```
WARNING: system-api-v0.3.0-r0 do_fetch: Failed to fetch URL git://github.com/flashbots/system-api;protocol=https;branch=main, attempting MIRRORS if available
ERROR: system-api-v0.3.0-r0 do_fetch: Fetcher failure: Unable to find revision 0d86deba121aeafdc3fb483b7c010d2bcd7b65cb in branch main even from upstream
ERROR: system-api-v0.3.0-r0 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'git://github.com/flashbots/system-api;protocol=https;branch=main')
ERROR: Logfile of failure stored in: /opt/data/artyom-yocto/tdx-rbuilder/srcs/poky/build/tmp/work/x86-64-v3-poky-linux/system-api/v0.3.0/temp/log.do_fetch.3163286
ERROR: Task (/opt/data/artyom-yocto/tdx-rbuilder/srcs/poky/meta-confidential-compute/recipes-core/system-api/system-api_v0.3.0.bb:do_fetch) failed with exit code '1'
```

Update the revision string format to reference the (possibly) dangling tag