### PR TITLE
Update cvm-reverse-proxy-server to listen on all interfaces

### DIFF
--- a/recipes-core/cvm-reverse-proxy-server/files/cvm-reverse-proxy-server-init
+++ b/recipes-core/cvm-reverse-proxy-server/files/cvm-reverse-proxy-server-init
@@ -12,7 +12,7 @@
 DAEMON=/usr/bin/proxy-server
 NAME=cvm-reverse-proxy-server
 DESC="CVM Reverse Proxy Server"
-DAEMON_ARGS="--listen-addr=localhost:7936 --target-addr=http://localhost:14727 --server-attestation-type azure-tdx"
+DAEMON_ARGS="--listen-addr=0.0.0.0:7936 --target-addr=http://localhost:14727 --server-attestation-type azure-tdx"
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/var/log/$NAME.log
 


### PR DESCRIPTION
cvm-reverse-proxy-server should be publicly available to receive orderflow