### PR TITLE
feat: Add better disk detection prior to encryption

### DIFF
--- a/recipes-core/disk-encryption/disk-encryption.bb
+++ b/recipes-core/disk-encryption/disk-encryption.bb
@@ -1,7 +1,29 @@
-DESCRIPTION = "enables persistent disk encryption of /dev/sda2 via tpm2"
+DESCRIPTION = "enables persistent disk encryption via tpm2"
 LICENSE = "CLOSED"
-RDEPENDS:${PN} += "cryptsetup tpm2-abrmd tpm2-tss tpm2-tools e2fsprogs-mke2fs"
+RDEPENDS:${PN} += "cryptsetup tpm2-abrmd tpm2-tss tpm2-tools e2fsprogs-mke2fs util-linux-lsblk"
 MACHINE_FEATURES += "disk-encryption"
+
+
+python () {
+    # Check if TARGET_LUN is set in the BitBake environment or in local.conf
+    target_lun = d.getVar('TARGET_LUN')
+    
+    if target_lun is None:
+        # If not set in BitBake environment, check the original environment
+        origenv = d.getVar("BB_ORIGENV", False)
+        if origenv:
+            target_lun = origenv.getVar('TARGET_LUN')
+    
+    if target_lun:
+        # If TARGET_LUN is set (to any non-empty value), keep its value
+        d.setVar('TARGET_LUN', target_lun)
+    else:
+        # If TARGET_LUN is not set, set it to '10' by default
+        d.setVar('TARGET_LUN', '10')
+
+    bb.note("Disk LUN number is set to %s" % d.getVar('TARGET_LUN'))
+}
+
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 SRC_URI += "file://init"
 
@@ -11,7 +33,12 @@ INITSCRIPT_PARAMS = "defaults 94"
 inherit update-rc.d
 
 do_install() {
-	install -d ${D}${sysconfdir}/init.d
-        cp ${WORKDIR}/init ${D}${sysconfdir}/init.d/disk-encryption
-        chmod 755 ${D}${sysconfdir}/init.d/disk-encryption
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/disk-encryption
+    
+    # Create environment file for TARGET_LUN
+    install -d ${D}${sysconfdir}/default
+    echo "TARGET_LUN=${TARGET_LUN}" > ${D}${sysconfdir}/default/disk-encryption
 }
+
+FILES:${PN} += "${sysconfdir}/default/disk-encryption"

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -32,7 +32,7 @@ find_target_disk() {
     local target_path
     
     # First try to find disk by LUN
-    target_path=$(readlink -f "/dev/disk/by-path/"*"scsi-0:0:0:${TARGET_LUN}" 2>/dev/null || true)
+    target_path=$(readlink -f /dev/disk/by-path/*scsi-0:0:0:${TARGET_LUN} 2>/dev/null || true)
     
     if [ -n "$target_path" ] && [ -b "$target_path" ]; then
         log "Found target disk at ${target_path} using LUN ${TARGET_LUN}"

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -19,8 +19,6 @@ DESC="Disk Encryption"
 KEYSIZE=64
 LOGFILE=/var/log/disk-encryption.log
 TPM_NV_INDEX=0x1500016
-# Default LUN number, can be overridden by environment variable
-TARGET_LUN="${TARGET_LUN:-10}"
 
 # Export TPM2TOOLS_TCTI
 export TPM2TOOLS_TCTI="device:/dev/tpmrm0"

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -10,12 +10,17 @@ set -eux -o pipefail
 # Short-Description:    Start and stop the disk-encryption daemon
 ### END INIT INFO
 
+# Source environment variables if file exists
+[ -r /etc/default/disk-encryption ] && . /etc/default/disk-encryption
+
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME=disk-encryption
 DESC="Disk Encryption"
 KEYSIZE=64
 LOGFILE=/var/log/disk-encryption.log
 TPM_NV_INDEX=0x1500016
+# Default LUN number, can be overridden by environment variable
+TARGET_LUN="${TARGET_LUN:-10}"
 
 # Export TPM2TOOLS_TCTI
 export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
@@ -23,6 +28,34 @@ export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
 log() {
     echo "$(date): $1" | tee -a $LOGFILE /dev/kmsg
     echo "$1" > /var/volatile/system-api.fifo
+}
+
+find_target_disk() {
+    local target_path
+    
+    # First try to find disk by LUN
+    target_path=$(readlink -f "/dev/disk/by-path/"*"scsi-0:0:0:${TARGET_LUN}" 2>/dev/null || true)
+    
+    if [ -n "$target_path" ] && [ -b "$target_path" ]; then
+        log "Found target disk at ${target_path} using LUN ${TARGET_LUN}"
+        echo "$target_path"
+        return 0
+    fi
+    
+    # Fallback: look for the first data disk that's not the boot disk
+    local boot_disk
+    boot_disk=$(mount | grep " on / " | cut -d' ' -f1 | sed 's/[0-9]*$//')
+    
+    for disk in $(lsblk -dpno name | grep "^/dev/sd"); do
+        if [ "$disk" != "$boot_disk" ]; then
+            log "Found target disk ${disk} as first non-boot disk"
+            echo "$disk"
+            return 0
+        fi
+    done
+    
+    log "No suitable target disk found"
+    return 1
 }
 
 generate_key() {
@@ -87,6 +120,7 @@ store_key_in_tpm() {
 
 start() {
     log "Starting $DESC"
+    echo "Starting $DESC" > /var/volatile/system-api.fifo
     
     # Error checking
     if [ ! -e /dev/tpm0 ] || [ ! -e /dev/tpmrm0 ]; then
@@ -94,10 +128,13 @@ start() {
         return 1
     fi
 
-    if [ ! -b /dev/sdb ]; then
-        log "Target disk /dev/sdb not found. Aborting disk encryption setup."
+    # Find target disk
+    TARGET_DISK=$(find_target_disk)
+    if [ $? -ne 0 ] || [ -z "$TARGET_DISK" ]; then
+        log "Failed to find target disk. Aborting disk encryption setup."
         return 1
     fi
+    log "Using disk: ${TARGET_DISK}"
 
     KEY=$(get_key)
     if [ $? -ne 0 ] || [ -z "$KEY" ]; then
@@ -116,13 +153,13 @@ start() {
         log "Existing key retrieved from TPM."
     fi
 
-    if ! echo -n "$KEY" | cryptsetup luksOpen /dev/sdb data - ; then
+    if ! echo -n "$KEY" | cryptsetup luksOpen "${TARGET_DISK}" data - ; then
         log "LUKS volume not opened successfully. Formatting and creating filesystem."
-        if ! echo -n "$KEY" | cryptsetup -q --batch-mode luksFormat /dev/sdb; then
+        if ! echo -n "$KEY" | cryptsetup -q --batch-mode luksFormat "${TARGET_DISK}"; then
             log "Failed to format LUKS volume. Aborting."
             return 1
         fi
-        if ! echo -n "$KEY" | cryptsetup luksOpen /dev/sdb data - ; then
+        if ! echo -n "$KEY" | cryptsetup luksOpen "${TARGET_DISK}" data - ; then
             log "Failed to open LUKS volume after formatting. Aborting."
             return 1
         fi

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -40,17 +40,15 @@ find_target_disk() {
         return 0
     fi
     
-    # Fallback: look for the first data disk that's not the boot disk
-    local boot_disk
-    boot_disk=$(mount | grep " on / " | cut -d' ' -f1 | sed 's/[0-9]*$//')
+    # Fallback: Simply find largest disk
+    local largest_disk
+    largest_disk=$(lsblk -bdnpo NAME,SIZE | grep "^/dev/sd" | sort -k2 -nr | head -1 | awk '{print $1}')
     
-    for disk in $(lsblk -dpno name | grep "^/dev/sd"); do
-        if [ "$disk" != "$boot_disk" ]; then
-            log "Found target disk ${disk} as first non-boot disk"
-            echo "$disk"
-            return 0
-        fi
-    done
+    if [ -n "$largest_disk" ] && [ -b "$largest_disk" ]; then
+        log "Found largest disk: ${largest_disk}"
+        echo "$largest_disk"
+        return 0
+    fi
     
     log "No suitable target disk found"
     return 1


### PR DESCRIPTION
This PR:
- Removes the hardcoded way of detecting the disk to format and encrypt
- Introduce the env variable TARGET_LUN during image build to specify which disk to fetch for encryption and mounting
- Two new methods to fetch a disk to encrypt: 
    1) using the TARGET_LUN and searching for the disk by path. 
    2) using lsblk to fetch the non-boot disk and encrypt it similar to what we had before. But in this case, it is not hardcoded to `/dev/sda`