### PR TITLE
fix: disk encryption TPM storage issues

### DIFF
--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -77,13 +77,12 @@ generate_key() {
 get_key() {
     # Attempt to read from the TPM2
     local key
-    key=$(tpm2_nvread $TPM_NV_INDEX 2>>$LOGFILE)
-    if [ -z "$key" ]; then
-        log "Failed to read TPM NV index. Check $LOGFILE for details."
-        printf ""
-        return 0
-    fi
-    printf "%s" "$key" 
+    key=$(tpm2_nvread $TPM_NV_INDEX 2>>$LOGFILE) || {
+        local exit_code=$?
+        log "Failed to read TPM NV index (exit code $exit_code). Check $LOGFILE for details."
+        return $exit_code
+    }
+    printf "%s" "$key"
     return 0
 }
 
@@ -128,8 +127,8 @@ start() {
     fi
     log "Using disk: ${TARGET_DISK}"
 
-    KEY=$(get_key)
-    if [ -z "$KEY" ]; then
+    KEY=$(get_key)|| exit_code=$?
+    if  [ $exit_code -ne 0 ] || [ -z "$KEY" ]; then
         log "No existing key in TPM. Generating new key."
         KEY=$(generate_key)
         if [ $? -ne 0 ] || [ -z "$KEY" ]; then

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -24,7 +24,8 @@ TPM_NV_INDEX=0x1500016
 export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
 
 log() {
-    echo "$(date): $1" | tee -a $LOGFILE /dev/kmsg
+    local message="$(date): $1"
+    echo "$message" >> $LOGFILE
     echo "$1" > /var/volatile/system-api.fifo
 }
 
@@ -42,11 +43,10 @@ find_target_disk() {
     
     # Fallback: Simply find largest disk
     local largest_disk
-    largest_disk=$(lsblk -bdnpo NAME,SIZE | grep "^/dev/sd" | sort -k2 -nr | head -1 | awk '{print $1}')
-    
+    largest_disk=$(lsblk -bdnpo NAME,SIZE | grep "^/dev/sd" | sort -k2 -nr | head -n 1 | awk '{print $1}')    
     if [ -n "$largest_disk" ] && [ -b "$largest_disk" ]; then
         log "Found largest disk: ${largest_disk}"
-        echo "$largest_disk"
+        echo "${largest_disk}"
         return 0
     fi
     
@@ -77,18 +77,14 @@ generate_key() {
 get_key() {
     # Attempt to read from the TPM2
     local key
-    local output
-    output=$(tpm2_nvread $TPM_NV_INDEX 2>&1)
-    key=$(echo "$output" | grep -v "ERROR" || true)
+    key=$(tpm2_nvread $TPM_NV_INDEX 2>>$LOGFILE)
     if [ -z "$key" ]; then
-        if [ -z "$output" ]; then
-            log "Failed to read TPM NV index. No output from tpm2_nvread."
-        else
-            log "Failed to read TPM NV index. Error: $output"
-        fi
-        return 1
+        log "Failed to read TPM NV index. Check $LOGFILE for details."
+        printf ""
+        return 0
     fi
-    echo "$key"
+    printf "%s" "$key" 
+    return 0
 }
 
 store_key_in_tpm() {
@@ -133,7 +129,7 @@ start() {
     log "Using disk: ${TARGET_DISK}"
 
     KEY=$(get_key)
-    if [ $? -ne 0 ] || [ -z "$KEY" ]; then
+    if [ -z "$KEY" ]; then
         log "No existing key in TPM. Generating new key."
         KEY=$(generate_key)
         if [ $? -ne 0 ] || [ -z "$KEY" ]; then


### PR DESCRIPTION
I tested it by running the following commands on a TDX base image built with this recipe
`tpm2_nvread 0x1500016 2>/dev/null # to verify that that the key was written to that index, it should output the used key for the disk encryption`

This however, does not solve the non persistent TPM issue within Azure as it seems to be an image configuration during deployment issue.
Reproduction steps regarding non persistent issues
```
tpm2_nvdefine <index> 2>/dev/null  # define an index to write a key into

echo "this is a test key" > key.txt  # this is an arbitrary message for debugging

tpm2_nvwrite <index> -i key.txt 2>/dev/null # write the key to that index

tpm2_nvread <index> 2>/dev/null # to verify that that the key was written to that index, it should output the message "this is a test key"

# reboot the system
reboot

#now read the value at index  <index> should return the stored value. However, it returns an error saying it is undefined index and has no value in it
tpm2_nvread  <index>  # returns an error

```