### PR TITLE
Allow fetching the disk encryption key from BuilderHub

### DIFF
--- a/recipes-core/disk-encryption/disk-encryption-key.mustache
+++ b/recipes-core/disk-encryption/disk-encryption-key.mustache
@@ -1,0 +1,1 @@
+{{{disk_encryption.key}}}

--- a/recipes-core/disk-encryption/disk-encryption.bb
+++ b/recipes-core/disk-encryption/disk-encryption.bb
@@ -53,4 +53,5 @@ do_install() {
     fi
 }
 
-FILES:${PN} += "${sysconfdir}/default/disk-encryption ${D}${sysconfdir}/disk-encryption/key.mustache"
+FILES:${PN} += "${sysconfdir}/default/disk-encryption"
+FILES:${PN}:append = " ${@bb.utils.contains('DISK_ENCRYPTION_KEY_STORAGE', 'file', '${D}${sysconfdir}/disk-encryption/key.mustache', '', d)}"

--- a/recipes-core/disk-encryption/disk-encryption.bb
+++ b/recipes-core/disk-encryption/disk-encryption.bb
@@ -3,29 +3,36 @@ LICENSE = "CLOSED"
 RDEPENDS:${PN} += "cryptsetup tpm2-abrmd tpm2-tss tpm2-tools e2fsprogs-mke2fs util-linux-lsblk"
 MACHINE_FEATURES += "disk-encryption"
 
+python() {
+    def get_var_with_origenv(d, var_name):
+        """Helper function to get variable from current or original environment."""
+        value = d.getVar(var_name)
+        if value is None:
+            origenv = d.getVar("BB_ORIGENV", False)
+            if origenv:
+                value = origenv.getVar(var_name)
+        return value
 
-python () {
-    # Check if TARGET_LUN is set in the BitBake environment or in local.conf
-    target_lun = d.getVar('TARGET_LUN')
+    # Set and validate TARGET_LUN
+    target_lun = get_var_with_origenv(d, 'TARGET_LUN')
+    d.setVar('TARGET_LUN', target_lun if target_lun else '10')
+    bb.note(f"Disk LUN number is set to {d.getVar('TARGET_LUN')}")
 
-    if target_lun is None:
-        # If not set in BitBake environment, check the original environment
-        origenv = d.getVar("BB_ORIGENV", False)
-        if origenv:
-            target_lun = origenv.getVar('TARGET_LUN')
+    # Set and validate DISK_ENCRYPTION_KEY_STORAGE
+    VALID_STORAGE_TYPES = {'tpm2', 'file'}
+    storage = get_var_with_origenv(d, 'DISK_ENCRYPTION_KEY_STORAGE')
+    storage = storage if storage else 'tpm2'
 
-    if target_lun:
-        # If TARGET_LUN is set (to any non-empty value), keep its value
-        d.setVar('TARGET_LUN', target_lun)
-    else:
-        # If TARGET_LUN is not set, set it to '10' by default
-        d.setVar('TARGET_LUN', '10')
+    if storage not in VALID_STORAGE_TYPES:
+        bb.fatal(f"DISK_ENCRYPTION_KEY_STORAGE must be set to one of: {', '.join(VALID_STORAGE_TYPES)}")
 
-    bb.note("Disk LUN number is set to %s" % d.getVar('TARGET_LUN'))
+    d.setVar('DISK_ENCRYPTION_KEY_STORAGE', storage)
+    bb.note(f"Disk encryption key storage is set to '{d.getVar('DISK_ENCRYPTION_KEY_STORAGE')}'")
 }
 
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
-SRC_URI += "file://init"
+SRC_URI += "file://init \
+            file://disk-encryption-key.mustache"
 
 INITSCRIPT_NAME = "disk-encryption"
 INITSCRIPT_PARAMS = "defaults 88"
@@ -36,9 +43,14 @@ do_install() {
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/disk-encryption
 
-    # Create environment file for TARGET_LUN
-    install -d ${D}${sysconfdir}/default
-    echo "TARGET_LUN=${TARGET_LUN}" > ${D}${sysconfdir}/default/disk-encryption
+    # Create environment file for init service
+    install -d ${D}${sysconfdir}/default ${D}${sysconfdir}/disk-encryption
+    echo "TARGET_LUN=${TARGET_LUN}
+    DISK_ENCRYPTION_KEY_STORAGE=${DISK_ENCRYPTION_KEY_STORAGE}" > ${D}${sysconfdir}/default/disk-encryption
+    if [ "$DISK_ENCRYPTION_KEY_STORAGE" = "file" ]; then
+        echo "DISK_ENCRYPTION_KEY_FILE=/etc/disk-encryption/key" >> ${D}${sysconfdir}/default/disk-encryption
+        install -m 0644 ${WORKDIR}/disk-encryption-key.mustache ${D}${sysconfdir}/disk-encryption/key.mustache
+    fi
 }
 
-FILES:${PN} += "${sysconfdir}/default/disk-encryption"
+FILES:${PN} += "${sysconfdir}/default/disk-encryption ${D}${sysconfdir}/disk-encryption/key.mustache"

--- a/recipes-core/disk-encryption/init
+++ b/recipes-core/disk-encryption/init
@@ -39,25 +39,25 @@ log() {
 
 find_target_disk() {
     local target_path
-    
+
     # First try to find disk by LUN
     target_path=$(readlink -f /dev/disk/by-path/*scsi-0:0:0:${TARGET_LUN} 2>/dev/null || true)
-    
+
     if [ -n "$target_path" ] && [ -b "$target_path" ]; then
         log "Found target disk at ${target_path} using LUN ${TARGET_LUN}"
         echo "$target_path"
         return 0
     fi
-    
+
     # Fallback: Simply find largest disk
     local largest_disk
-    largest_disk=$(lsblk -bdnpo NAME,SIZE | grep "^/dev/sd" | sort -k2 -nr | head -n 1 | awk '{print $1}')    
+    largest_disk=$(lsblk -bdnpo NAME,SIZE | grep "^/dev/sd" | sort -k2 -nr | head -n 1 | awk '{print $1}')
     if [ -n "$largest_disk" ] && [ -b "$largest_disk" ]; then
         log "Found largest disk: ${largest_disk}"
         echo "${largest_disk}"
         return 0
     fi
-    
+
     log "No suitable target disk found"
     return 1
 }
@@ -83,15 +83,22 @@ generate_key() {
 }
 
 get_key() {
-    # Attempt to read from the TPM2
-    local key
-    key=$(tpm2_nvread $TPM_NV_INDEX 2>>$LOGFILE) || {
-        local exit_code=$?
-        log "Failed to read TPM NV index (exit code $exit_code). Check $LOGFILE for details."
-        return $exit_code
-    }
-    printf "%s" "$key"
-    return 0
+    case "$DISK_ENCRYPTION_KEY_STORAGE" in
+        tpm2)
+            get_key_from_tpm
+            ;;
+        file)
+            if [ -z "$DISK_ENCRYPTION_KEY_FILE" ]; then
+                log "DISK_ENCRYPTION_KEY_FILE not set"
+                return 1
+            fi
+            get_key_from_file
+            ;;
+        *)
+            log "Invalid DISK_ENCRYPTION_KEY_STORAGE value: $DISK_ENCRYPTION_KEY_STORAGE"
+            return 1
+            ;;
+    esac
 }
 
 store_key_in_tpm() {
@@ -117,6 +124,32 @@ store_key_in_tpm() {
     log "Successfully stored key in TPM"
 }
 
+get_key_from_tpm() {
+    # Attempt to read from the TPM2
+    local key
+    key=$(tpm2_nvread $TPM_NV_INDEX 2>>$LOGFILE) || {
+        local exit_code=$?
+        log "Failed to read TPM NV index (exit code $exit_code). Check $LOGFILE for details."
+        return $exit_code
+    }
+    printf "%s" "$key"
+    return 0
+}
+
+get_key_from_file() {
+    if [ ! -f "$DISK_ENCRYPTION_KEY_FILE" ]; then
+        log "Key file not found: $DISK_ENCRYPTION_KEY_FILE"
+        return 1
+    fi
+
+    local key
+    key=$(cat "$DISK_ENCRYPTION_KEY_FILE")
+
+    printf "%s" "$key"
+    rm -f "$DISK_ENCRYPTION_KEY_FILE"
+    return 0
+}
+
 start() {
     log "Starting $DESC"
 
@@ -134,21 +167,26 @@ start() {
     fi
     log "Using disk: ${TARGET_DISK}"
 
-    KEY=$(get_key)|| exit_code=$?
-    if  [ $exit_code -ne 0 ] || [ -z "$KEY" ]; then
-        log "No existing key in TPM. Generating new key."
-        KEY=$(generate_key)
-        if [ $? -ne 0 ] || [ -z "$KEY" ]; then
-            log "Key generation failed. Aborting."
+    KEY=$(get_key) || exit_code=$?
+    if [ $exit_code -ne 0 ] || [ -z "$KEY" ]; then
+        if [ "$DISK_ENCRYPTION_KEY_STORAGE" = "tpm2" ]; then
+            log "No existing key in TPM. Generating new key."
+            KEY=$(generate_key)
+            if [ $? -ne 0 ] || [ -z "$KEY" ]; then
+                log "Key generation failed. Aborting."
+                return 1
+            fi
+            if ! store_key_in_tpm "$KEY"; then
+                log "Failed to store new key in TPM. Aborting."
+                return 1
+            fi
+            log "New key generated and stored in TPM."
+        else
+            log "Failed to read encryption key. Aborting."
             return 1
         fi
-        if ! store_key_in_tpm "$KEY"; then
-            log "Failed to store new key in TPM. Aborting."
-            return 1
-        fi
-        log "New key generated and stored in TPM."
     else
-        log "Existing key retrieved from TPM."
+        log "Existing key retrieved from storage."
     fi
 
     if ! echo -n "$KEY" | cryptsetup luksOpen "${TARGET_DISK}" data - ; then


### PR DESCRIPTION
TPM module's NVRAM on Azure is not persistent thus cannot be used to store the disk encryption key, it will be gone after the reboot.

Allow fetching the disk encryption key from BuilderHub and use it as an alternative option for encrypting the disk. By default the key storage is set to `tpm2`. During the image build a user can override `DISK_ENCRYPTION_KEY_STORAGE` and set it to `file` to enable fetching the key from BuilderHub.