### PR TITLE
Create System API fake FIFO in runtime

### DIFF
--- a/recipes-core/images/cvm-initramfs.bb
+++ b/recipes-core/images/cvm-initramfs.bb
@@ -7,7 +7,7 @@ that can subsequently be picked up by external image generation tools such as wi
 
 CVM_DEPS = "busybox-mdev init-ifupdown initscripts base-files base-passwd netbase busybox-udhcpd"
 
-PACKAGE_INSTALL = "ca-certificates sysvinit busybox-udhcpd date-sync logrotate cronie ${CVM_DEPS} ${VIRTUAL-RUNTIME_base-utils} ${ROOTFS_BOOTSTRAP_INSTALL}"
+PACKAGE_INSTALL = "ca-certificates sysvinit busybox-udhcpd date-sync logrotate cronie ${CVM_DEPS} ${VIRTUAL-RUNTIME_base-utils} ${ROOTFS_BOOTSTRAP_INSTALL} system-api-fake-fifo"
 
 INITRAMFS_MAXSIZE = "20000000"
 
@@ -16,13 +16,13 @@ IMAGE_FEATURES = ""
 python () {
     # Check if DEBUG_TWEAKS_ENABLED is set in the environment or in local.conf
     debug_tweaks_enabled = d.getVar('DEBUG_TWEAKS_ENABLED')
-    
+
     if debug_tweaks_enabled is None:
         # If not set, check the original environment
         origenv = d.getVar("BB_ORIGENV", False)
         if origenv:
             debug_tweaks_enabled = origenv.getVar('DEBUG_TWEAKS_ENABLED')
-    
+
     if debug_tweaks_enabled:
         # If DEBUG_TWEAKS_ENABLED is set (to any non-empty value), keep its value
         d.setVar('DEBUG_TWEAKS_ENABLED', debug_tweaks_enabled)

--- a/recipes-core/system-api-fake-fifo/init
+++ b/recipes-core/system-api-fake-fifo/init
@@ -1,0 +1,29 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          system-api-fake-fifo
+# Required-Start:    $remote_fs $syslog $network
+# Default-Start:     2 3 4 5
+# Short-Description: Start System API fake FIFO
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME=system-api-fake-fifo
+DESC="Create a regular file to accumulate system events before System API starts"
+
+start() {
+  install -m 0666 /var/volatile/system-api.fifo
+  echo "Starting $NAME" | tee -a /var/volatile/system-api.fifo
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/recipes-core/system-api-fake-fifo/system-api-fake-fifo.bb
+++ b/recipes-core/system-api-fake-fifo/system-api-fake-fifo.bb
@@ -1,10 +1,18 @@
+SUMMARY = "System API fake FIFO"
 DESCRIPTION = "Create a regular file to accumulate system events before System API starts"
 LICENSE = "CLOSED"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}:"
+
+SRC_URI += "file://init"
+
+INITSCRIPT_NAME = "system-api-fake-fifo"
+INITSCRIPT_PARAMS = "defaults 60"
+
+inherit update-rc.d
+
 do_install() {
-    install -m 1777 -d ${D}/var/volatile
-    touch ${D}/var/volatile/system-api.fifo
-    chmod 666 ${D}/var/volatile/system-api.fifo
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/${INITSCRIPT_NAME} ${D}${sysconfdir}/init.d/${INITSCRIPT_NAME}
 }
 
-FILES:${PN} = "/var/volatile/system-api.fifo"


### PR DESCRIPTION
`/var/volatile` is not available in the image build time. Replace fake FIFO creation to happen in runtime.