### PR TITLE
Fix: date-sync

### DIFF
--- a/recipes-core/date-sync/init
+++ b/recipes-core/date-sync/init
@@ -26,7 +26,7 @@ log() {
         }
     else
         date_log() {
-            echo -n "$(date --iso-8601=seconds): "
+            echo -n "$(date -u +"%Y-%m-%dT%H:%M:%SZ"): "
         }
     fi
     echo "$(date_log)$1" >&2 | tee -a $SYSTEM_API_FIFO

--- a/recipes-core/date-sync/init
+++ b/recipes-core/date-sync/init
@@ -43,11 +43,15 @@ monitor_and_restart() {
     done
 }
 
+
 start() {
+    log "Initial sync..."
+    $DAEMON -d -q -g -p "$NTP_SERVER"
+
     log "Starting $NAME"
     start-stop-daemon -S --make-pidfile --pidfile $PIDFILE \
         --background --startas /bin/sh -- -c "exec \
-        ${DAEMON} -n -d -p $NTP_SERVER \
+        ${DAEMON} -n -d -g -p $NTP_SERVER \
         2>&1 | tee ${LOGFILE}"
 
     # Start the monitor in the background


### PR DESCRIPTION
System time is consistently 9 seconds behind in multiple bob deployments. 

The likely culprit is that BusyBox ntpd is never stepping the clock to correct any initial offset. By default, BusyBox ntpd in daemon mode only slews the clock (gradually adjusts), and if the local clock is already off by several seconds at startup, it can remain off (or take a very long time to converge).

Manpage: https://linux.die.net/man/8/ntpd

