### PR TITLE
chore: remove unnecessary debug build flags

### DIFF
--- a/recipes-core/images/cvm-initramfs.bb
+++ b/recipes-core/images/cvm-initramfs.bb
@@ -13,32 +13,6 @@ INITRAMFS_MAXSIZE = "20000000"
 
 # Do not pollute the initrd image with rootfs features
 IMAGE_FEATURES = ""
-python () {
-    # Check if DEBUG_TWEAKS_ENABLED is set in the environment or in local.conf
-    debug_tweaks_enabled = d.getVar('DEBUG_TWEAKS_ENABLED')
-
-    if debug_tweaks_enabled is None:
-        # If not set, check the original environment
-        origenv = d.getVar("BB_ORIGENV", False)
-        if origenv:
-            debug_tweaks_enabled = origenv.getVar('DEBUG_TWEAKS_ENABLED')
-
-    if debug_tweaks_enabled:
-        # If DEBUG_TWEAKS_ENABLED is set (to any non-empty value), keep its value
-        d.setVar('DEBUG_TWEAKS_ENABLED', debug_tweaks_enabled)
-    else:
-        # If DEBUG_TWEAKS_ENABLED is not set, set it to '1' by default
-        d.setVar('DEBUG_TWEAKS_ENABLED', '0')
-
-    # set the image features based on the value of DEBUG_TWEAKS_ENABLED
-    if d.getVar('DEBUG_TWEAKS_ENABLED') == '1':
-        # give a warning that the debug tweaks are enabled
-        bb.warn("Debug tweaks are enabled in the image")
-        # add the debug-tweaks feature to the image if DEBUG_TWEAKS_ENABLED is set
-        d.appendVar('IMAGE_FEATURES', ' debug-tweaks')
-        # add dropbear to the package install list to be able to login for debugging purposes
-        d.appendVar('PACKAGE_INSTALL', ' dropbear')
-}
 
 export IMAGE_BASENAME = "cvm-initramfs"
 IMAGE_NAME_SUFFIX ?= ""


### PR DESCRIPTION
This PR removes the build with debug flags since each of the products (BuilderNet and BoB) have their own dropbear and ssh configuration setup in their own layers. No need to have this conditionally here anymore as part of the base image.