### PR TITLE
Update systemapi-config.toml.mustache: basic auth clarification

### DIFF
--- a/recipes-core/system-api/files/systemapi-config.toml.mustache
+++ b/recipes-core/system-api/files/systemapi-config.toml.mustache
@@ -5,8 +5,8 @@ pprof = false
 log_json = true
 log_debug = false
 
-# HTTP Basic Auth
-basic_auth_secret_path = "/persistent/system-api/basic-auth-secret"
+# HTTP Basic Auth: the salt, and where to persistently store the hashed secret
+basic_auth_secret_path = "/persistent/system-api/basic-auth-hash"
 basic_auth_secret_salt = "1_drink_coffee:|"
 
 # HTTP server timeouts


### PR DESCRIPTION
makes it clearer that only the hash is stored