### PR TITLE
Fixes for v1.3 release

### DIFF
--- a/recipes-core/cvm-reverse-proxy-client/files/cvm-reverse-proxy-client-init
+++ b/recipes-core/cvm-reverse-proxy-client/files/cvm-reverse-proxy-client-init
@@ -9,10 +9,12 @@
 # Description:       Enable CVM Reverse Proxy Client service.
 ### END INIT INFO
 
+. /etc/init-config.conf || true
+
 DAEMON=/usr/bin/proxy-client
 NAME=cvm-reverse-proxy-client
 DESC="CVM Reverse Proxy Client"
-DAEMON_ARGS="--listen-addr=localhost:7937 --target-addr=https://hub-atls.builder.flashbots.net --client-attestation-type azure-tdx --server-attestation-type none"
+DAEMON_ARGS="--listen-addr=localhost:7937 --target-addr=${INIT_CONFIG_URL:-http://localhost:8080} --client-attestation-type azure-tdx --server-attestation-type none"
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/var/log/$NAME.log
 SYSTEM_API_FIFO=/var/volatile/system-api.fifo

--- a/recipes-core/initscripts/files/status-all.patch
+++ b/recipes-core/initscripts/files/status-all.patch
@@ -1,0 +1,42 @@
+diff --git a/script/service b/script/service
+index 08f69bb..14872dc 100755
+--- a/script/service
++++ b/script/service
+@@ -73,36 +73,7 @@ while [ $# -gt 0 ]; do
+        ;;
+     *)
+        if [ -z "${SERVICE}" -a $# -eq 1 -a "${1}" = "--status-all" ]; then
+-          cd ${SERVICEDIR}
+-          for SERVICE in * ; do
+-            case "${SERVICE}" in
+-              functions | halt | killall | single| linuxconf| kudzu)
+-                  ;;
+-              *)
+-                if ! is_ignored_file "${SERVICE}" \
+-		    && [ -x "${SERVICEDIR}/${SERVICE}" ]; then
+-                        out=$(env -i LANG="$LANG" LANGUAGE="$LANGUAGE" LC_CTYPE="$LC_CTYPE" LC_NUMERIC="$LC_NUMERIC" LC_TIME="$LC_TIME" LC_COLLATE="$LC_COLLATE" LC_MONETARY="$LC_MONETARY" LC_MESSAGES="$LC_MESSAGES" LC_PAPER="$LC_PAPER" LC_NAME="$LC_NAME" LC_ADDRESS="$LC_ADDRESS" LC_TELEPHONE="$LC_TELEPHONE" LC_MEASUREMENT="$LC_MEASUREMENT" LC_IDENTIFICATION="$LC_IDENTIFICATION" LC_ALL="$LC_ALL" PATH="$PATH" TERM="$TERM" "$SERVICEDIR/$SERVICE" status 2>&1)
+-                        retval=$?
+-                        if echo "$out" | grep -Fiq "usage:"; then
+-                          #printf " %s %-60s %s\n" "[?]" "$SERVICE:" "unknown" 1>&2
+-                          echo " [ ? ]  $SERVICE" 1>&2
+-                          continue
+-                        else
+-                          if [ "$retval" = "0" -a -n "$out" ]; then
+-                            #printf " %s %-60s %s\n" "[+]" "$SERVICE:" "running"
+-                            echo " [ + ]  $SERVICE"
+-                            continue
+-                          else
+-                            #printf " %s %-60s %s\n" "[-]" "$SERVICE:" "NOT running"
+-                            echo " [ - ]  $SERVICE"
+-                            continue
+-                          fi
+-                        fi
+-                  #env -i LANG="$LANG" LANGUAGE="$LANGUAGE" LC_CTYPE="$LC_CTYPE" LC_NUMERIC="$LC_NUMERIC" LC_TIME="$LC_TIME" LC_COLLATE="$LC_COLLATE" LC_MONETARY="$LC_MONETARY" LC_MESSAGES="$LC_MESSAGES" LC_PAPER="$LC_PAPER" LC_NAME="$LC_NAME" LC_ADDRESS="$LC_ADDRESS" LC_TELEPHONE="$LC_TELEPHONE" LC_MEASUREMENT="$LC_MEASUREMENT" LC_IDENTIFICATION="$LC_IDENTIFICATION" LC_ALL="$LC_ALL" PATH="$PATH" TERM="$TERM" "$SERVICEDIR/$SERVICE" status
+-                fi
+-                ;;
+-            esac
+-          done
++          echo "Not implemented." >&2
+           exit 0
+        elif [ $# -eq 2 -a "${2}" = "--full-restart" ]; then
+           SERVICE="${1}"

--- a/recipes-core/initscripts/init-system-helpers_1.66.bbappend
+++ b/recipes-core/initscripts/init-system-helpers_1.66.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://status-all.patch"

--- a/recipes-core/logrotate/files/default-logrotate.conf
+++ b/recipes-core/logrotate/files/default-logrotate.conf
@@ -6,4 +6,5 @@
     compress
     notifempty
     copytruncate
+    dateformat -%Y%m%d-%H%M%S
 }

--- a/recipes-core/logrotate/files/logrotate-frequent.cron
+++ b/recipes-core/logrotate/files/logrotate-frequent.cron
@@ -1,1 +1,1 @@
-*/10 * * * * root /usr/sbin/logrotate /etc/logrotate.conf
+*/10 * * * * root /usr/sbin/logrotate -v -l /var/log/logrotate.log /etc/logrotate.conf

--- a/recipes-core/logrotate/logrotate_%.bbappend
+++ b/recipes-core/logrotate/logrotate_%.bbappend
@@ -9,7 +9,7 @@ do_install:append() {
 
     # Install a cron job that runs logrotate every 10 minutes
     install -d ${D}${sysconfdir}/cron.d
-    install -m 0755 ${WORKDIR}/logrotate-frequent.cron ${D}${sysconfdir}/cron.d/logrotate-frequent
+    install -m 0640 ${WORKDIR}/logrotate-frequent.cron ${D}${sysconfdir}/cron.d/logrotate-frequent
 
     # Install a default logrotate configuration
     install -d ${D}${sysconfdir}/logrotate.d


### PR DESCRIPTION
- Make BuilderHub URL configurable with `INIT_CONFIG_URL` environment variable. The URL has already been stored in `/etc/init-config.conf` file but never used.
- Fix permissions on the cron job file for logrotate. It was set to 755 before which prevented crond from executing it thus logs have never been rotated. The cron job file should not be executable. 
- Use separate log file for logrotate and make the output more verbose. Without it crontab uses `sendmail` by default to send the results of the execution to the `root` user but `sendmail` binary is missing from the image.
- Add `dateformat` to the logrotate config. By default logrotate adds `-%Y%m%d` suffix to rotated logs but it fails if there are more than one rotated file per day (our case) rejecting to replace the file.
- Patch `service` "binary" (shell script) to not bork the system when `service --status-all` is executed.

<details>
  <summary>Details about `service --status-all` bug</summary>
  
  Since we use SysVInit for service management all our services are plain Shell scripts. When `service --status-all` is executed it looks for `status()` function inside each service definition file and executes it. If there is code that is not wrapped into a function it is executed as well.
The last words of the VM after executing the command is:
```
root@tdx:~# service --status-all
 [ - ]  banner.sh
 [ - ]  bootlogd
 [ - ]  bootmisc.sh
 [ ? ]  busybox-udhcpd
 [ - ]  checkroot.sh
 [ + ]  crond
 [ ? ]  cvm-reverse-proxy-client-init
 [ ? ]  cvm-reverse-proxy-server-init
 [ ? ]  date-sync
 [ - ]  devpts.sh
 [ ? ]  disk-encryption
 [ - ]  dmesg.sh
 [ ? ]  dropbear
 [ ? ]  fetch-config
 [ ? ]  haproxy
 [ - ]  hostname.sh
 [ ? ]  lighthouse
 [ ? ]  mdev
 [ - ]  mountall.sh
 [ - ]  mountnfs.sh
 [ ? ]  networking
 [ + ]  node_exporter
 [ - ]  orderflow-proxy-init
 [ ? ]  podman-init
 [ - ]  populate-volatile.sh
 [ + ]  process-exporter
 [ + ]  prometheus
 [ ? ]  rbuilder
 [ - ]  rbuilder-bidding
 [ - ]  read-only-rootfs-hook.sh
 [ ? ]  reth
 [ ? ]  reth-sync
 [ - ]  rmnologin.sh
 [ + ]  run-postinsts
 [ - ]  save-rtc.sh
```
The next service that the command would check the status for is sendsigs which looks like this:
```
...
# Kill all processes.
echo "Sending all processes the TERM signal..."
killall5 -15
sleep 5
echo "Sending all processes the KILL signal..."
killall5 -9
...
```
There is no `status()` function defined and attempting to check the status for this service would run the script killing all the processes on the running system.
The service file is part of the standard installation and probably used as the last script to run before shutting down the system.
</details>
